### PR TITLE
Fix header anchor URLs after rebasing onto main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Build and deploy site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/public/404.html
+++ b/public/404.html
@@ -7,6 +7,14 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      (function () {
+        var redirect = sessionStorage.getItem('spa-redirect');
+        if (!redirect) {
+          sessionStorage.setItem('spa-redirect', window.location.pathname + window.location.search + window.location.hash);
+        }
+      })();
+    </script>
     <script src="./bundle.js"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ const App = () => (
       <Route path="/:lang" element={<Layout />}>
         <Route index element={<LandingPage />} />
         <Route path="docs" element={<DocsIndex />} />
-        <Route path="docs/:slug" element={<DocPage />} />
+        <Route path="docs/*" element={<DocPage />} />
         <Route path="*" element={<NotFound />} />
       </Route>
       <Route path="*" element={<Navigate to="/zh-CN" replace />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 const Footer = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const currentLocale = i18n.language === 'en' ? 'en' : 'zh-CN';
+  const basePath = `/${currentLocale}`;
 
   return (
     <footer id="contact" className="site-footer">
@@ -18,18 +21,10 @@ const Footer = () => {
           <h4>{t('footer.docs')}</h4>
           <ul>
             <li>
-              <a href="https://majora3.iinti.cn/majora-doc/" target="_blank" rel="noopener noreferrer">
-                {t('footer.officialDoc')}
-              </a>
+              <Link to={`${basePath}/docs`}>{t('footer.officialDoc')}</Link>
             </li>
             <li>
-              <a
-                href="https://majora3.iinti.cn/majora-doc/01_deploy/01_overview.html"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {t('footer.deployOverview')}
-              </a>
+              <Link to={`${basePath}/docs/quick-start`}>{t('footer.deployOverview')}</Link>
             </li>
             <li>
               <a href="mailto:contact@iinti.cn">{t('footer.contactEmail')}</a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import LanguageSwitcher from './LanguageSwitcher';
+import { withBasePath } from '../utils/basePath';
 
 const Header = () => {
   const { t } = useTranslation();
@@ -31,6 +32,8 @@ const Header = () => {
     scrollToElement();
   };
 
+  const anchorHref = (section: string) => withBasePath(`${basePath}#${section}`);
+
   return (
     <header className="site-header">
       <div className="container nav">
@@ -41,17 +44,22 @@ const Header = () => {
           <span className="tagline">Proxy Platform</span>
         </div>
         <nav className="navigation" aria-label="Primary">
-          <a href={`${basePath}#features`} onClick={handleScroll('features')}>
+          <a href={anchorHref('features')} onClick={handleScroll('features')}>
             {t('nav.features')}
           </a>
-          <a href={`${basePath}#steps`} onClick={handleScroll('steps')}>
+          <a href={anchorHref('steps')} onClick={handleScroll('steps')}>
             {t('nav.steps')}
           </a>
-          <a href={`${basePath}#clients`} onClick={handleScroll('clients')}>
+          <a href={anchorHref('clients')} onClick={handleScroll('clients')}>
             {t('nav.clients')}
           </a>
-          <Link to={`${basePath}/docs`}>{t('nav.docs')}</Link>
-          <a href={`${basePath}#contact`} onClick={handleScroll('contact')}>
+          <a href="https://majora3.iinti.cn/majora-doc/" target="_blank" rel="noopener noreferrer">
+            {t('nav.docs')}
+          </a>
+          <a href="https://github.com/yint-tech/majora-open" target="_blank" rel="noopener noreferrer">
+            {t('nav.github')}
+          </a>
+          <a href={anchorHref('contact')} onClick={handleScroll('contact')}>
             {t('nav.contact')}
           </a>
         </nav>

--- a/src/content/docs.ts
+++ b/src/content/docs.ts
@@ -11,28 +11,31 @@ export type DocRecord = {
 
 type DocsByLocale = Record<DocRecord['locale'], DocRecord[]>;
 
-const docsContext = require.context('../docs', false, /\.(?:zh-CN|en)\.md$/);
+const docsContext = require.context('../docs', true, /\.(?:zh-CN|en)\.md$/);
 
-const docs: DocRecord[] = docsContext.keys().map((key) => {
-  const raw = docsContext(key) as string;
-  const { data, content } = matter(raw);
+const docs: DocRecord[] = docsContext
+  .keys()
+  .sort()
+  .map((key) => {
+    const raw = docsContext(key) as string;
+    const { data, content } = matter(raw);
 
-  const match = key.match(/\.\/(.+)\.(zh-CN|en)\.md$/);
-  if (!match) {
-    throw new Error(`Invalid docs filename: ${key}`);
-  }
+    const match = key.match(/\.\/(.+)\.(zh-CN|en)\.md$/);
+    if (!match) {
+      throw new Error(`Invalid docs filename: ${key}`);
+    }
 
-  const [, slug, locale] = match;
+    const [, slug, locale] = match;
 
-  return {
-    slug,
-    locale: locale as DocRecord['locale'],
-    title: (data.title as string | undefined) ?? slug,
-    description: data.description as string | undefined,
-    updated: data.updated as string | undefined,
-    content,
-  };
-});
+    return {
+      slug,
+      locale: locale as DocRecord['locale'],
+      title: (data.title as string | undefined) ?? slug,
+      description: data.description as string | undefined,
+      updated: data.updated as string | undefined,
+      content,
+    };
+  });
 
 export const docsByLocale: DocsByLocale = docs.reduce<DocsByLocale>(
   (acc, doc) => {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -4,7 +4,8 @@
     "steps": "Setup",
     "clients": "Clients",
     "contact": "Contact",
-    "docs": "Docs"
+    "docs": "Docs",
+    "github": "GitHub"
   },
   "language": {
     "label": "Language",
@@ -13,12 +14,13 @@
   },
   "hero": {
     "eyebrow": "Get Started · Advanced",
-    "title": "Launch your proxy service in one click and connect devices worldwide",
-    "description": "Majora centralises proxy infrastructure so you can federate diverse devices into a governed, scalable IP pool with ease.",
-    "primaryCta": "Try the demo account",
-    "secondaryCta": "Browse full docs",
+    "title": "Self-host a proxy cluster in one click\nConnect private network devices in seconds",
+    "description": "Aggregate global endpoints\nBuild a governed and scalable proxy IP pool",
+    "primaryCta": "Get started",
+    "secondaryCta": "Browse docs",
     "note": "Demo credentials: {{credentials}}",
-    "introCta": "Read the introduction"
+    "introCta": "Read the introduction",
+    "repoCta": "View on GitHub"
   },
   "cards": [
     {
@@ -64,7 +66,7 @@
       "Open the console: the first registered account becomes the admin user (demo credentials remain available)."
     ],
     "code": "yum install -y docker\ndocker pull registry.cn-beijing.aliyuncs.com/iinti/majora3:all-in-one\ndocker run -d --network host \\\n  -v ~/majora3-mysql-data:/var/lib/mysql \\\n  --name majora3 \\\n  registry.cn-beijing.aliyuncs.com/iinti/majora3:all-in-one\necho \"Browse http://127.0.0.1:6879 and login with majora/majora\"\necho \"The first registered account becomes the admin user\"",
-    "linkLabel": "Open the console"
+    "linkLabel": "View setup guide"
   },
   "clients": {
     "title": "Client access in minutes",
@@ -73,36 +75,34 @@
         "title": "VPS nodes",
         "description": "Linux binaries cover dedicated servers and cloud hosts with batch-friendly operations.",
         "primaryAction": "Setup guide",
-        "primaryLink": "https://majora3.iinti.cn/majora-doc/01_deploy/02_client_01_bin.html"
+        "primaryLink": "/docs/quick-start"
       },
       {
         "title": "Router terminals",
         "description": "OpenWrt and other routers integrate quickly to onboard residential or office broadband.",
-        "primaryAction": "Request solution",
-        "primaryLink": "https://majora3.iinti.cn/majora-doc/"
+        "primaryAction": "Integration overview",
+        "primaryLink": "/docs/introduction"
       },
       {
         "title": "Android 4G devices",
         "description": "Hardened Android app turns phones and SBCs into stable 4G proxy exports.",
-        "primaryAction": "Download APK",
-        "primaryLink": "https://oss.iinti.cn/majora3/Majora3.apk",
-        "secondaryAction": "Install guide",
-        "secondaryLink": "https://majora3.iinti.cn/majora-doc/01_deploy/02_client_02_android.html"
+        "primaryAction": "Usage guide",
+        "primaryLink": "/docs/android-client"
       }
     ]
   },
   "cta": {
     "title": "Build your enterprise proxy network",
     "description": "Deliver secure and stable connectivity backed by Majora's reliability and scalability.",
-    "action": "Open console"
+    "action": "View GitHub project"
   },
   "footer": {
     "products": "IINTI Portfolio | Majora · Sekiro · Malenia",
     "business": "Business",
     "businessDescription": "Scan the QR code or add WeChat {{wechat}} to join the community.",
     "docs": "Docs & Support",
-    "officialDoc": "Docs portal",
-    "deployOverview": "Deployment overview",
+    "officialDoc": "Docs hub",
+    "deployOverview": "Quick start",
     "contactEmail": "Email",
     "copyright": "© 2022-present IINTI"
   },

--- a/src/i18n/locales/zh-CN/translation.json
+++ b/src/i18n/locales/zh-CN/translation.json
@@ -4,7 +4,8 @@
     "steps": "安装步骤",
     "clients": "多端接入",
     "contact": "联系与合作",
-    "docs": "文档"
+    "docs": "文档",
+    "github": "GitHub"
   },
   "language": {
     "label": "语言",
@@ -13,12 +14,13 @@
   },
   "hero": {
     "eyebrow": "开始使用 · 高阶深入",
-    "title": "一键完成代理服务搭建，秒级接入全球网络设备",
-    "description": "Majora 是面向代理业务的一体化集群控制中心，轻松聚合分散的网络设备并形成可监管、可扩展的代理 IP 池。",
-    "primaryCta": "立即体验测试账户",
-    "secondaryCta": "浏览完整文档",
+    "title": "一键自建代理服务集群\n秒级接入自主网络设备",
+    "description": "聚合全球网络终端\n构建可监管、可扩展的代理 IP 池",
+    "primaryCta": "快速开始",
+    "secondaryCta": "浏览文档",
     "note": "测试账号：{{credentials}}",
-    "introCta": "阅读系统导言"
+    "introCta": "阅读系统导言",
+    "repoCta": "GitHub 仓库"
   },
   "cards": [
     {
@@ -64,7 +66,7 @@
       "登录控制台：首个注册用户即为 admin 管理账号，亦可使用测试账号体验。"
     ],
     "code": "yum install -y docker\ndocker pull registry.cn-beijing.aliyuncs.com/iinti/majora3:all-in-one\ndocker run -d --network host \\\n  -v ~/majora3-mysql-data:/var/lib/mysql \\\n  --name majora3 \\\n  registry.cn-beijing.aliyuncs.com/iinti/majora3:all-in-one\necho \"访问 http://127.0.0.1:6879 使用账号 majora/majora 登录\"\necho \"首个注册用户即为 admin 管理账号\"",
-    "linkLabel": "打开管理后台"
+    "linkLabel": "查看安装指引"
   },
   "clients": {
     "title": "多端客户端快速接入",
@@ -73,36 +75,34 @@
         "title": "VPS 节点",
         "description": "Linux 一键客户端覆盖各类服务器与云主机，支持批量部署与脚本运维。",
         "primaryAction": "部署指南",
-        "primaryLink": "https://majora3.iinti.cn/majora-doc/01_deploy/02_client_01_bin.html"
+        "primaryLink": "/docs/quick-start"
       },
       {
         "title": "路由器终端",
         "description": "OpenWrt 等路由环境可快速集成，把家庭/企业宽带纳入代理池。",
-        "primaryAction": "获取方案",
-        "primaryLink": "https://majora3.iinti.cn/majora-doc/"
+        "primaryAction": "接入说明",
+        "primaryLink": "/docs/introduction"
       },
       {
         "title": "Android 4G 设备",
         "description": "Android 客户端稳定运行在手机或开发板，实现 4G 流量代理输出。",
-        "primaryAction": "下载 APK",
-        "primaryLink": "https://oss.iinti.cn/majora3/Majora3.apk",
-        "secondaryAction": "安装指南",
-        "secondaryLink": "https://majora3.iinti.cn/majora-doc/01_deploy/02_client_02_android.html"
+        "primaryAction": "使用指南",
+        "primaryLink": "/docs/android-client"
       }
     ]
   },
   "cta": {
     "title": "开始构建您的企业级代理网络",
     "description": "依托 Majora 的高可靠性与灵活拓展能力，快速上线代理 IP 服务，为业务提供安全、稳定的网络支撑。",
-    "action": "登录控制台"
+    "action": "查看 GitHub 项目"
   },
   "footer": {
     "products": "因体关联产品 | Majora · Sekiro · Malenia",
     "business": "商务合作",
     "businessDescription": "扫描商务二维码或添加微信 {{wechat}} 加入交流群。",
     "docs": "文档与支持",
-    "officialDoc": "官方文档",
-    "deployOverview": "部署概览",
+    "officialDoc": "文档中心",
+    "deployOverview": "快速开始",
     "contactEmail": "联系邮箱",
     "copyright": "© 2022-至今 IINTI"
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './styles/global.css';
 import './i18n/config';
+import { appBasePath } from './utils/basePath';
 
 const container = document.getElementById('root');
 
@@ -12,11 +13,18 @@ if (!container) {
   throw new Error('Root container missing');
 }
 
+const savedRedirect = sessionStorage.getItem('spa-redirect');
+if (savedRedirect) {
+  const normalized = savedRedirect.startsWith('/') ? savedRedirect : `/${savedRedirect}`;
+  window.history.replaceState(null, document.title, normalized || '/');
+  sessionStorage.removeItem('spa-redirect');
+}
+
 const root = createRoot(container);
 
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={appBasePath || undefined}>
       <App />
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/pages/DocPage.tsx
+++ b/src/pages/DocPage.tsx
@@ -6,17 +6,21 @@ import { marked } from 'marked';
 import { getDoc, getFallbackDoc, type DocRecord } from '../content/docs';
 
 const DocPage = () => {
-  const { lang, slug } = useParams<{ lang?: string; slug?: string }>();
+  const params = useParams<{ lang?: string; '*': string }>();
+  const { lang } = params;
   const { t } = useTranslation();
 
   const locale: DocRecord['locale'] = lang === 'en' ? 'en' : 'zh-CN';
   const basePath = `/${locale}`;
 
+  const slug = params['*'];
+
   const doc = useMemo(() => {
     if (!slug) {
       return undefined;
     }
-    return getDoc(slug, locale) ?? getFallbackDoc(slug);
+    const normalizedSlug = slug.replace(/\/+$/, '');
+    return getDoc(normalizedSlug, locale) ?? getFallbackDoc(normalizedSlug);
   }, [slug, locale]);
 
   const isFallback = doc ? doc.locale !== locale : false;

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -24,10 +24,25 @@ type ConceptItem = {
   description: string;
 };
 
+const renderWithLineBreaks = (text: string): ReactNode => {
+  if (!text.includes('\n')) {
+    return text;
+  }
+
+  return text.split('\n').map((part, index) => (
+    <span key={`line-${index}`} className="line-break">
+      {part}
+    </span>
+  ));
+};
+
+const isExternalLink = (url: string): boolean => /^https?:\/\//.test(url);
+
 const LandingPage = () => {
   const { t, i18n } = useTranslation();
   const location = useLocation();
-  const basePath = i18n.language === 'en' ? '/en' : '/zh-CN';
+  const currentLocale = i18n.language === 'en' ? 'en' : 'zh-CN';
+  const basePath = `/${currentLocale}`;
 
   const cards = t('cards', { returnObjects: true }) as FeatureItem[];
   const features = t('features.items', { returnObjects: true }) as FeatureItem[];
@@ -54,23 +69,26 @@ const LandingPage = () => {
         <div className="container hero-content">
           <div className="hero-text">
             <p className="eyebrow">{t('hero.eyebrow')}</p>
-            <h1>{t('hero.title')}</h1>
-            <p className="lead">{t('hero.description')}</p>
+            <h1>{renderWithLineBreaks(t('hero.title'))}</h1>
+            <p className="lead">{renderWithLineBreaks(t('hero.description'))}</p>
             <div className="hero-actions">
-              <a className="button primary" href="http://majora3.iinti.cn/" target="_blank" rel="noopener noreferrer">
+              <Link className="button primary" to={`${basePath}/docs/quick-start`}>
                 {t('hero.primaryCta')}
-              </a>
-              <a
-                className="button ghost"
-                href="https://majora3.iinti.cn/majora-doc/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              </Link>
+              <Link className="button ghost" to={`${basePath}/docs`}>
                 {t('hero.secondaryCta')}
-              </a>
+              </Link>
               <Link className="button ghost small" to={`${basePath}/docs/introduction`}>
                 {t('hero.introCta')}
               </Link>
+              <a
+                className="button ghost small"
+                href="https://github.com/yint-tech/majora-open"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('hero.repoCta')}
+              </a>
             </div>
             <p className="note">
               {t('hero.note', {
@@ -87,47 +105,6 @@ const LandingPage = () => {
                 </div>
               ))}
             </div>
-          </div>
-        </div>
-      </section>
-
-      <section id="clients" className="section clients">
-        <div className="container">
-          <h2>{t('clients.title')}</h2>
-          <div className="client-grid">
-            {clients.map((client) => (
-              <article key={client.title} className="client-card">
-                <h3>{client.title}</h3>
-                <p>{client.description}</p>
-                {client.code ? (
-                  <pre>
-                    <code>{client.code}</code>
-                  </pre>
-                ) : null}
-                <div className="actions">
-                  {client.primaryAction && client.primaryLink ? (
-                    <a
-                      className="button primary"
-                      href={client.primaryLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {client.primaryAction}
-                    </a>
-                  ) : null}
-                  {client.secondaryAction && client.secondaryLink ? (
-                    <a
-                      className="button ghost"
-                      href={client.secondaryLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {client.secondaryAction}
-                    </a>
-                  ) : null}
-                </div>
-              </article>
-            ))}
           </div>
         </div>
       </section>
@@ -177,10 +154,63 @@ const LandingPage = () => {
               <code>{stepCode}</code>
             </pre>
             {stepLinkLabel ? (
-              <a className="button ghost" href="http://majora3.iinti.cn/" target="_blank" rel="noopener noreferrer">
+              <Link className="button ghost" to={`${basePath}/docs/quick-start`}>
                 {stepLinkLabel}
-              </a>
+              </Link>
             ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section id="clients" className="section clients">
+        <div className="container">
+          <h2>{t('clients.title')}</h2>
+          <div className="client-grid">
+            {clients.map((client) => (
+              <article key={client.title} className="client-card">
+                <h3>{client.title}</h3>
+                <p>{client.description}</p>
+                {client.code ? (
+                  <pre>
+                    <code>{client.code}</code>
+                  </pre>
+                ) : null}
+                <div className="actions">
+                  {client.primaryAction && client.primaryLink ? (
+                    isExternalLink(client.primaryLink) ? (
+                      <a
+                        className="button primary"
+                        href={client.primaryLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {client.primaryAction}
+                      </a>
+                    ) : (
+                      <Link className="button primary" to={`${basePath}${client.primaryLink}`}>
+                        {client.primaryAction}
+                      </Link>
+                    )
+                  ) : null}
+                  {client.secondaryAction && client.secondaryLink ? (
+                    isExternalLink(client.secondaryLink) ? (
+                      <a
+                        className="button ghost"
+                        href={client.secondaryLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {client.secondaryAction}
+                      </a>
+                    ) : (
+                      <Link className="button ghost" to={`${basePath}${client.secondaryLink}`}>
+                        {client.secondaryAction}
+                      </Link>
+                    )
+                  ) : null}
+                </div>
+              </article>
+            ))}
           </div>
         </div>
       </section>
@@ -192,7 +222,12 @@ const LandingPage = () => {
               <h2 id="cta-title">{t('cta.title')}</h2>
               <p>{t('cta.description')}</p>
             </div>
-            <a className="button primary" href="http://majora3.iinti.cn/" target="_blank" rel="noopener noreferrer">
+            <a
+              className="button primary"
+              href="https://github.com/yint-tech/majora-open"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {t('cta.action')}
             </a>
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -168,6 +168,13 @@ ul {
   color: var(--muted);
   max-width: 32rem;
 }
+.hero-text .line-break {
+  display: block;
+}
+
+.hero-text .line-break + .line-break {
+  margin-top: 0.4rem;
+}
 
 .hero-text .eyebrow {
   color: var(--accent);
@@ -232,11 +239,11 @@ ul {
 }
 
 .secondary-card {
-  transform: translate(24px, -18px);
+  transform: translate(32px, -12px);
 }
 
 .tertiary-card {
-  transform: translate(-16px, 12px);
+  transform: translate(-20px, 20px);
 }
 
 .section {

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -1,0 +1,27 @@
+const SUPPORTED_LOCALES = new Set(['zh-CN', 'en']);
+
+const detectBasePath = (): string => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  const segments = window.location.pathname.split('/').filter(Boolean);
+  const localeIndex = segments.findIndex((segment) => SUPPORTED_LOCALES.has(segment));
+
+  if (localeIndex > 0) {
+    return `/${segments.slice(0, localeIndex).join('/')}`;
+  }
+
+  if (window.location.hostname.endsWith('github.io') && segments.length > 0) {
+    return `/${segments[0]}`;
+  }
+
+  return '';
+};
+
+export const appBasePath = detectBasePath();
+
+export const withBasePath = (path: string): string => {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${appBasePath}${normalized}`.replace(/\/+/g, '/');
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
     clean: true,
-    publicPath: '/',
+    publicPath: 'auto',
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js', '.jsx'],
@@ -42,6 +42,10 @@ module.exports = {
         {
           from: path.resolve(__dirname, 'public'),
           to: path.resolve(__dirname, 'dist'),
+        },
+        {
+          from: path.resolve(__dirname, 'public', 'index.html'),
+          to: path.resolve(__dirname, 'dist', '404.html'),
         },
       ],
     }),


### PR DESCRIPTION
## Summary
- update the header navigation to build anchor links with the base-path helper instead of the removed toAbsoluteUrl utility
- remove the duplicated GitHub navigation item introduced during the rebase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cdd55184832299f746063eacdeca